### PR TITLE
Remove Content-Type header from the Collection file

### DIFF
--- a/pdfRest API.postman_collection.json
+++ b/pdfRest API.postman_collection.json
@@ -14,13 +14,6 @@
 					"name": "Convert to PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -126,13 +119,6 @@
 					"name": "Convert to PDF/A",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -194,13 +180,6 @@
 					"name": "Compress PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -263,13 +242,6 @@
 					"name": "Linearize PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -319,13 +291,6 @@
 					"name": "Flatten Transparencies",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -381,13 +346,6 @@
 					"name": "Merge PDFs",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -481,13 +439,6 @@
 					"name": "Split PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -549,13 +500,6 @@
 					"name": "PDF to Images - BMP",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -617,13 +561,6 @@
 					"name": "PDF to Images - GIF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -685,13 +622,6 @@
 					"name": "PDF to Images - JPG",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -759,13 +689,6 @@
 					"name": "PDF to Images - PNG",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -827,13 +750,6 @@
 					"name": "PDF to Images - TIF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -901,13 +817,6 @@
 					"name": "Encrypt PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -971,13 +880,6 @@
 					"name": "Decrypt PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1040,13 +942,6 @@
 					"name": "Restrict PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1128,13 +1023,6 @@
 					"name": "Unrestrict PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1197,13 +1085,6 @@
 					"name": "ZIP Files",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1265,13 +1146,6 @@
 					"name": "Query PDF",
 					"request": {
 						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1336,7 +1210,7 @@
 			"script": {
 				"type": "text/javascript",
 				"exec": [
-					""
+					" pm.request.headers.add({key: 'wsn', value: 'Postman' })"
 				]
 			}
 		},


### PR DESCRIPTION
The `Content-Type` header is duplicated when the Collection is imported into Postman. When using the **online app** in a web browser, this causes an unexpected error response from each endpoint:

```
{
    "error": "The file or id fields are missing or filled incorrectly. Verify fields and try again."
}
```
I've never reproduced this error in the desktop app.

It looks like Postman already includes this header automatically (click "Hidden" to view them in Postman).
<img width="588" alt="Screen Shot 2023-01-25 at 11 52 28 AM" src="https://user-images.githubusercontent.com/19696151/214643504-a4c2b815-875b-4185-b32e-6b0871b28cb8.png">

As things currently stand, we have two headers called `Content-Type`:

<img width="712" alt="Screen Shot 2023-01-25 at 11 53 45 AM" src="https://user-images.githubusercontent.com/19696151/214644052-b45dd189-3b48-4090-95fe-ff2fb597d306.png">

Each endpoint appears to behave itself when the second one is removed from our Collection.