### PR TITLE
Add new Requests to demo various input file formats

### DIFF
--- a/pdfRest API.postman_collection.json
+++ b/pdfRest API.postman_collection.json
@@ -11,9 +11,10 @@
 			"name": "Convert to PDF",
 			"item": [
 				{
-					"name": "Convert to PDF",
+					"name": "Convert Office file (Word, Excel, PowerPoint) to PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -31,9 +32,99 @@
 									"disabled": true
 								},
 								{
+									"key": "compression",
+									"value": "lossy",
+									"description": "(.ps, Office, HTML) Image compression level",
+									"type": "text"
+								},
+								{
+									"key": "downsample",
+									"value": "300",
+									"description": "(.ps, Office, HTML) Image downsampling level",
+									"type": "text"
+								},
+								{
+									"key": "tagged_pdf",
+									"value": "off",
+									"description": "(Office) Toggle tagged PDF output",
+									"type": "text"
+								},
+								{
+									"key": "output",
+									"value": "pdf_out",
+									"description": "Output file name (no ext.)",
+									"type": "text"
+								},
+								{
 									"key": "url",
 									"value": "",
 									"description": "URL to be processed",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "page_size",
+									"value": "letter",
+									"description": "(HTML) Output page size",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "page_margin",
+									"value": "1in",
+									"description": "(HTML) Output page margin",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "page_orientation",
+									"value": "portrait",
+									"description": "(HTML) Output page orientation",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "web_layout",
+									"value": "desktop",
+									"description": "(HTML) Web layout",
+									"type": "text",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "https://api.pdfrest.com/pdf",
+							"protocol": "https",
+							"host": [
+								"api",
+								"pdfrest",
+								"com"
+							],
+							"path": [
+								"pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Convert image file (JPG, PNG, TIF, BMP) to PDF",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"description": "File to be processed",
+									"type": "file",
+									"src": []
+								},
+								{
+									"key": "id",
+									"value": "",
+									"description": "Resource ID to be processed",
 									"type": "text",
 									"disabled": true
 								},
@@ -42,6 +133,13 @@
 									"value": "pdf_out",
 									"description": "Output file name (no ext.)",
 									"type": "text"
+								},
+								{
+									"key": "url",
+									"value": "",
+									"description": "URL to be processed",
+									"type": "text",
+									"disabled": true
 								},
 								{
 									"key": "compression",
@@ -108,6 +206,100 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Convert HTML to PDF",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"description": "File to be processed",
+									"type": "file",
+									"src": []
+								},
+								{
+									"key": "id",
+									"value": "",
+									"description": "Resource ID to be processed",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "url",
+									"value": "",
+									"description": "URL to be processed",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "compression",
+									"value": "lossy",
+									"description": "(.ps, Office, HTML) Image compression level",
+									"type": "text"
+								},
+								{
+									"key": "downsample",
+									"value": "300",
+									"description": "(.ps, Office, HTML) Image downsampling level",
+									"type": "text"
+								},
+								{
+									"key": "page_size",
+									"value": "letter",
+									"description": "(HTML) Output page size",
+									"type": "text"
+								},
+								{
+									"key": "page_margin",
+									"value": "1in",
+									"description": "(HTML) Output page margin",
+									"type": "text"
+								},
+								{
+									"key": "page_orientation",
+									"value": "portrait",
+									"description": "(HTML) Output page orientation",
+									"type": "text"
+								},
+								{
+									"key": "web_layout",
+									"value": "desktop",
+									"description": "(HTML) Web layout",
+									"type": "text"
+								},
+								{
+									"key": "output",
+									"value": "pdf_out",
+									"description": "Output file name (no ext.)",
+									"type": "text"
+								},
+								{
+									"key": "tagged_pdf",
+									"value": "off",
+									"description": "(Office) Toggle tagged PDF output",
+									"type": "text",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "https://api.pdfrest.com/pdf",
+							"protocol": "https",
+							"host": [
+								"api",
+								"pdfrest",
+								"com"
+							],
+							"path": [
+								"pdf"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"description": "Quickly and easily convert Word, Excel, PowerPoint, BMP, TIF, PNG, and JPG files to standardized PDF documents."
@@ -116,9 +308,10 @@
 			"name": "Convert to PDF/A",
 			"item": [
 				{
-					"name": "Convert to PDF/A",
+					"name": "Convert PDF to a specified version of PDF/A",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -177,9 +370,10 @@
 			"name": "Compress PDF",
 			"item": [
 				{
-					"name": "Compress PDF",
+					"name": "Compress PDF file size",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -239,9 +433,10 @@
 			"name": "Linearize PDF",
 			"item": [
 				{
-					"name": "Linearize PDF",
+					"name": "Enable Fast Web Viewing in a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -288,9 +483,10 @@
 			"name": "Flatten Transparencies",
 			"item": [
 				{
-					"name": "Flatten Transparencies",
+					"name": "Flatten transparencies in a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -343,9 +539,10 @@
 			"name": "Merge PDFs",
 			"item": [
 				{
-					"name": "Merge PDFs",
+					"name": "Merge PDFs by page range(s)",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -436,9 +633,10 @@
 			"name": "Split PDF",
 			"item": [
 				{
-					"name": "Split PDF",
+					"name": "Split PDF by page range(s)",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -461,9 +659,65 @@
 									"description": "Pages from the input document that will comprise a new output document.",
 									"type": "text"
 								},
-                {
+								{
 									"key": "pages[]",
 									"value": "odd",
+									"description": "Pages from the input document that will comprise a new output document.",
+									"type": "text"
+								},
+								{
+									"key": "pages[]",
+									"value": "1,3,4-6",
+									"description": "Pages from the input document that will comprise a new output document.",
+									"type": "text"
+								},
+								{
+									"key": "output",
+									"value": "split_out",
+									"description": "Output file name (no ext.)",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://api.pdfrest.com/split-pdf",
+							"protocol": "https",
+							"host": [
+								"api",
+								"pdfrest",
+								"com"
+							],
+							"path": [
+								"split-pdf"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete page(s) in PDF",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "file",
+									"description": "File to be processed",
+									"type": "file",
+									"src": []
+								},
+								{
+									"key": "id",
+									"value": "",
+									"description": "Resource ID to be processed",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "pages[]",
+									"value": "1-3,5-last",
 									"description": "Pages from the input document that will comprise a new output document.",
 									"type": "text"
 								},
@@ -497,9 +751,10 @@
 			"name": "PDF to Images",
 			"item": [
 				{
-					"name": "PDF to Images - BMP",
+					"name": "Convert PDF to BMP",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -558,9 +813,10 @@
 					"response": []
 				},
 				{
-					"name": "PDF to Images - GIF",
+					"name": "Convert PDF to GIF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -619,9 +875,10 @@
 					"response": []
 				},
 				{
-					"name": "PDF to Images - JPG",
+					"name": "Convert PDF to JPG",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -686,9 +943,10 @@
 					"response": []
 				},
 				{
-					"name": "PDF to Images - PNG",
+					"name": "Convert PDF to PNG",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -747,9 +1005,10 @@
 					"response": []
 				},
 				{
-					"name": "PDF to Images - TIF",
+					"name": "Convert PDF to TIF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -814,9 +1073,10 @@
 			"name": "Encrypt PDF",
 			"item": [
 				{
-					"name": "Encrypt PDF",
+					"name": "Encrypt a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -877,9 +1137,10 @@
 					"response": []
 				},
 				{
-					"name": "Decrypt PDF",
+					"name": "Remove encryption from a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -939,9 +1200,10 @@
 			"name": "Restrict PDF",
 			"item": [
 				{
-					"name": "Restrict PDF",
+					"name": "Add security restrictions to a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1020,9 +1282,10 @@
 					"response": []
 				},
 				{
-					"name": "Unrestrict PDF",
+					"name": "Remove security restrictions from a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1082,9 +1345,10 @@
 			"name": "ZIP Files",
 			"item": [
 				{
-					"name": "ZIP Files",
+					"name": "ZIP files",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1143,9 +1407,10 @@
 			"name": "Query PDF",
 			"item": [
 				{
-					"name": "Query PDF",
+					"name": "Get metadata from a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [
@@ -1192,9 +1457,10 @@
 			"name": "Add to PDF",
 			"item": [
 				{
-					"name": "Add image",
+					"name": "Add an image (JPG, PNG, TIF, GIF) to a page in a PDF",
 					"request": {
 						"method": "POST",
+						"header": [],
 						"body": {
 							"mode": "formdata",
 							"formdata": [

--- a/pdfRest API.postman_collection.json
+++ b/pdfRest API.postman_collection.json
@@ -52,7 +52,7 @@
 								{
 									"key": "output",
 									"value": "pdf_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -131,7 +131,7 @@
 								{
 									"key": "output",
 									"value": "pdf_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -274,7 +274,7 @@
 								{
 									"key": "output",
 									"value": "pdf_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -331,7 +331,7 @@
 								{
 									"key": "output",
 									"value": "pdfa_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -393,7 +393,7 @@
 								{
 									"key": "output",
 									"value": "compressed_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -456,7 +456,7 @@
 								{
 									"key": "output",
 									"value": "linearized_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								}
 							]
@@ -506,7 +506,7 @@
 								{
 									"key": "output",
 									"value": "flattened_transparencies_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -606,7 +606,7 @@
 								{
 									"key": "output",
 									"value": "merged_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								}
 							]
@@ -674,7 +674,7 @@
 								{
 									"key": "output",
 									"value": "split_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								}
 							]
@@ -724,7 +724,7 @@
 								{
 									"key": "output",
 									"value": "split_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								}
 							]
@@ -774,7 +774,7 @@
 								{
 									"key": "output",
 									"value": "bmp_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -836,7 +836,7 @@
 								{
 									"key": "output",
 									"value": "gif_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -898,7 +898,7 @@
 								{
 									"key": "output",
 									"value": "jpg_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -966,7 +966,7 @@
 								{
 									"key": "output",
 									"value": "png_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1028,7 +1028,7 @@
 								{
 									"key": "output",
 									"value": "tif_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1096,7 +1096,7 @@
 								{
 									"key": "output",
 									"value": "encrypt_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1160,7 +1160,7 @@
 								{
 									"key": "output",
 									"value": "decrypt_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1223,7 +1223,7 @@
 								{
 									"key": "output",
 									"value": "restrict_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1305,7 +1305,7 @@
 								{
 									"key": "output",
 									"value": "unrestrict_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{
@@ -1380,7 +1380,7 @@
 								{
 									"key": "output",
 									"value": "zip_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								}
 							]
@@ -1493,7 +1493,7 @@
 								{
 									"key": "output",
 									"value": "pdf_out",
-									"description": "Output file name (no ext.)",
+									"description": "Output file name (no file extension)",
 									"type": "text"
 								},
 								{


### PR DESCRIPTION
Renames some requests in our Collection to be more descriptive.

Adds some more requests within the existing API Tool directories to demo more functionality, such as `/pdf` input formats.