### PR TITLE
Fix workspace id access

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -16,4 +16,4 @@ jobs:
       uses: jneate/postman-collection-action@v1
       with:
         postmanApiKey: ${{ secrets.POSTMAN_API_KEY }}
-        postmanWorkspaceId: ${{ env.POSTMAN_WORKSPACE_ID }}
+        postmanWorkspaceId: ${{ vars.POSTMAN_WORKSPACE_ID }}


### PR DESCRIPTION
The Workspace ID wasn't accessed correctly. It's a configuration variable, not an environment variable, so it requires the `vars` context. More at https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values