### PR TITLE
Fix most issues with the last workflow runs

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -1,17 +1,15 @@
 name: Update Postman Workspace
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches: [ develop ]
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  update-postman-collection:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Sync Postman Collections
       uses: jneate/postman-collection-action@v1
       with:


### PR DESCRIPTION
- Update version of Checkout used to v3 to match latest
- Change trigger to be pushes to develop instead of merges so the agent running it is Datalogics. This lets it use secrets and variables from the Datalogics repo.